### PR TITLE
Early finishing fix

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -149,6 +149,11 @@ class Batch(models.Model):
         except StopIteration:
             pass
 
+        if self.commands().filter(status=BatchCommand.STATUS_INITIAL):
+            logger.warning(f"[{self}] finished running but still has init commands, restarting...")
+            self.status = Batch.STATUS_INITIAL
+            self.save()
+            return
         self.finish()
 
     def start(self):

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 
 from django.conf import settings
 from django.db import models
+from django.db import transaction
 from django.utils.translation import gettext as _
 
 from .client import Client
@@ -242,6 +243,7 @@ class Batch(models.Model):
         else:
             return []
 
+    @transaction.atomic
     def save_batch_and_preview_commands(self):
         self.status = self.STATUS_INITIAL
         if not self.pk:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -149,7 +149,7 @@ class Batch(models.Model):
         except StopIteration:
             pass
 
-        if self.commands().filter(status=BatchCommand.STATUS_INITIAL):
+        if self.commands().filter(status=BatchCommand.STATUS_INITIAL).exists():
             logger.warning(f"[{self}] finished running but still has init commands, restarting...")
             self.status = Batch.STATUS_INITIAL
             self.save()


### PR DESCRIPTION
It seems that #219 (and, probably, #243 and #244) may be caused by a race condition with `send_batches`. Specifically, as soon as a batch is created and assigned a private key, it is immediately set to `INITIAL` status. This allows the batch to be executed before all commands have been added, resulting in the execution of only the commands that were present at that time.