### PR TITLE
fix: allow 2+ letters (and hyphens) in language codes

### DIFF
--- a/src/core/parsers/base.py
+++ b/src/core/parsers/base.py
@@ -83,7 +83,7 @@ class BaseParser(object):
         Len
         Lpt
         """
-        return value is not None and re.match("^L[a-z]{2}$", value) is not None
+        return value is not None and re.match(r"^L[a-z-]{2,}$", value) is not None
 
     def is_valid_alias(self, value):
         """
@@ -91,7 +91,7 @@ class BaseParser(object):
         Aen
         Apt
         """
-        return value is not None and re.match("^A[a-z]{2}$", value) is not None
+        return value is not None and re.match(r"^A[a-z-]{2,}$", value) is not None
 
     def is_valid_description(self, value):
         """
@@ -99,14 +99,14 @@ class BaseParser(object):
         Den
         Dpt
         """
-        return value is not None and re.match("^D[a-z]{2}$", value) is not None
+        return value is not None and re.match(r"^D[a-z-]{2,}$", value) is not None
 
     def is_valid_sitelink(self, value):
         """
         Returns True if value is a valid sitelink
         Swiki
         """
-        return value is not None and re.match("^S[a-z]+$", value) is not None
+        return value is not None and re.match(r"^S[a-z]{2,}$", value) is not None
 
     def is_valid_statement_rank(self, value):
         """

--- a/src/core/tests/test_base_parser.py
+++ b/src/core/tests/test_base_parser.py
@@ -115,30 +115,36 @@ class TestBaseParser(TestCase):
     def test_sense_valid_alias_parser(self):
         parser = BaseParser()
         self.assertTrue(parser.is_valid_alias("Aen"))
+        self.assertTrue(parser.is_valid_alias("Apt-br"))
+        self.assertTrue(parser.is_valid_alias("Amul"))
         self.assertFalse(parser.is_valid_alias("Ae"))
-        self.assertFalse(parser.is_valid_alias("Aeadsdasdadasd"))
+        self.assertTrue(parser.is_valid_alias("Aeadsdasdadasd"))
         self.assertFalse(parser.is_valid_alias("A1212"))
         self.assertFalse(parser.is_valid_alias(None))
 
     def test_sense_valid_description_parser(self):
         parser = BaseParser()
         self.assertTrue(parser.is_valid_description("Den"))
+        self.assertTrue(parser.is_valid_description("Dpt-br"))
+        self.assertTrue(parser.is_valid_description("Dmul"))
         self.assertFalse(parser.is_valid_description("De"))
-        self.assertFalse(parser.is_valid_description("Deeqweqweqwe"))
+        self.assertTrue(parser.is_valid_description("Deeqweqweqwe"))
         self.assertFalse(parser.is_valid_description("D1212"))
         self.assertFalse(parser.is_valid_description(None))
 
     def test_sense_valid_label_parser(self):
         parser = BaseParser()
         self.assertTrue(parser.is_valid_label("Len"))
+        self.assertTrue(parser.is_valid_label("Lpt-br"))
+        self.assertTrue(parser.is_valid_label("Lmul"))
         self.assertFalse(parser.is_valid_label("Le"))
-        self.assertFalse(parser.is_valid_label("Lefsfdsfdsf"))
+        self.assertTrue(parser.is_valid_label("Lefsfdsfdsf"))
         self.assertFalse(parser.is_valid_label("L1212"))
         self.assertFalse(parser.is_valid_label(None))
 
     def test_sense_valid_sitelink_parser(self):
         parser = BaseParser()
-        self.assertTrue(parser.is_valid_sitelink("Swikibr"))
+        self.assertTrue(parser.is_valid_sitelink("Sptwiki"))
         self.assertFalse(parser.is_valid_sitelink("S2121212"))
         self.assertFalse(parser.is_valid_sitelink(None))
 

--- a/src/core/tests/test_csv_parser.py
+++ b/src/core/tests/test_csv_parser.py
@@ -605,7 +605,7 @@ class TestCSVParser(TestCase):
 
     def test_parse_label(self):
         parser = CSVCommandParser()
-        result = parser.parse_line(["Q4115189", "Regina Phalange"], ["qid", "Len"])
+        result = parser.parse_line(["Q4115189", "Regina Phalange"], ["qid", "Lpt-br"])
         self.assertEqual(
             result,
             [
@@ -614,14 +614,14 @@ class TestCSVParser(TestCase):
                     "item": "Q4115189",
                     "value": {"type": "string", "value": "Regina Phalange"},
                     "what": "label",
-                    "language": "en",
+                    "language": "pt-br",
                 },
             ],
         )
 
     def test_parse_description(self):
         parser = CSVCommandParser()
-        result = parser.parse_line(["Q4115189", "Ma maison"], ["qid", "Dfr"])
+        result = parser.parse_line(["Q4115189", "Ma maison"], ["qid", "Dmul"])
         self.assertEqual(
             result,
             [
@@ -630,7 +630,7 @@ class TestCSVParser(TestCase):
                     "item": "Q4115189",
                     "value": {"type": "string", "value": "Ma maison"},
                     "what": "description",
-                    "language": "fr",
+                    "language": "mul",
                 },
             ],
         )


### PR DESCRIPTION
Should fix #242 