### PR TITLE
Allow selection of wikibase before submitting batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-### Deprecated
- - `BASE_REST_URL` will be removed in a future version and wikibases will be managed via the admin
+### Added
+ - `DEFAULT_WIKIBASE_URL` environment variables to set the wikibase (Default: 'https://wikidata.org')
+ - `WHITELISTED_USERS` is a comma-separated list of usernames that
+   will always be allowed to submit batches, even if not autoconfirmed (Default: empty list)
+
+### Removed
+ - `BASE_REST_URL` is no longer supported. Use `DEFAULT_WIKIBASE_URL` instead.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3.8'
 
+
 x-application-service: &application-service
   build:
     context: ./
@@ -23,7 +24,12 @@ x-application-service: &application-service
     - ./etc/env
   volumes:
     - ./src:/home/wmb/www/python/src
-    - static-data:/home/wmb/www/python/static
+    - qs-static-data:/home/wmb/www/python/static
+
+x-wikibase-volumes: &wikibase-volumes
+  volumes:
+    - wikibase-config-data:/config
+    - wikibase-static-data:/var/www/html/images
 
 services:
   mariadb:
@@ -34,10 +40,8 @@ services:
       # use the root user
       MARIADB_DATABASE: quickstatements
       MARIADB_ROOT_PASSWORD: quickstatements_pass
-    expose:
-      - "3306"
     volumes:
-      - mariadb_data:/var/lib/mysql
+      - qs-mariadb-data:/var/lib/mysql
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       start_period: 10s
@@ -51,8 +55,10 @@ services:
     ports:
       - "8000:80"
     volumes:
-      - static-data:/static
+      - qs-static-data:/static
       - ./etc/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - app
 
   app:
     <<: *application-service
@@ -70,6 +76,57 @@ services:
     <<: *application-service
     command: django-admin send_batches
 
+  wikibase:
+    <<: *wikibase-volumes
+    image: wikibase/wikibase:4.0
+    ports:
+      - 8888:80
+    environment:
+      MW_ADMIN_NAME: "${WIKIBASE_ADMIN_USERNAME:-admin}"
+      MW_ADMIN_PASS: "${WIKIBASE_ADMIN_PASSWORD:-wikibase_admin_pass}"
+      MW_ADMIN_EMAIL: "${WIKIBASE_ADMIN_EMAIL:-admin@wikibase.example}"
+      MW_WG_SERVER: http://localhost:8888
+      DB_SERVER: wikibase-db:3306
+      DB_NAME: wikibase
+      DB_USER: wikibase
+      DB_PASS: wikibase_pass
+    healthcheck:
+      test: curl --silent --fail localhost/wiki/Main_Page
+      interval: 10s
+      start_period: 5m
+    depends_on:
+      wikibase-db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  wikibase-jobrunner:
+    <<: *wikibase-volumes
+    image: wikibase/wikibase:4.0
+    command: /jobrunner-entrypoint.sh
+    depends_on:
+      wikibase:
+        condition: service_healthy
+    restart: unless-stopped
+
+  wikibase-db:
+    image: mariadb:10.11
+    environment:
+      MARIADB_DATABASE: wikibase
+      MARIADB_USER: wikibase
+      MARIADB_PASSWORD: wikibase_pass
+      MARIADB_RANDOM_ROOT_PASSWORD: yes
+    healthcheck:
+      test: healthcheck.sh --connect --innodb_initialized
+      start_period: 1m
+      interval: 20s
+      timeout: 5s
+    restart: unless-stopped
+    volumes:
+      - wikibase-db-data:/var/lib/mysql
+
 volumes:
-  mariadb_data:
-  static-data:
+  qs-mariadb-data:
+  qs-static-data:
+  wikibase-config-data:
+  wikibase-static-data:
+  wikibase-db-data:

--- a/etc/env.SAMPLE
+++ b/etc/env.SAMPLE
@@ -3,7 +3,7 @@ DJANGO_SECRET_KEY=<SECRETKEY>
 OAUTH_CLIENT_ID=
 OAUTH_CLIENT_SECRET=
 
-BASE_REST_URL=<optional>
+DEFAULT_WIKIBASE_URL=<optional>
 # example: https://test.wikidata.org
 # defaults to: https://www.wikidata.org
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,6 @@ DJANGO_SETTINGS_MODULE = qsts3.settings
 python_files = tests.py test_*.py
 
 env =
-    BASE_REST_URL = https://wikidata.example.org
+    DEFAULT_WIKIBASE_URL = https://wikidata.example.org
     OAUTH_AUTHORIZATION_SERVER = https://oauth.example.org
+    WHITELISTED_USERS=

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -48,7 +48,7 @@ oauth.register(
 
 
 def get_default_wikibase():
-    parsed_root_enpoint = urlparse(settings.BASE_REST_URL)
+    parsed_root_enpoint = urlparse(settings.DEFAULT_WIKIBASE_URL)
     default_wikibase_url = (
         f"{parsed_root_enpoint.scheme}://{parsed_root_enpoint.netloc}"
     )
@@ -148,7 +148,17 @@ class Client:
         return profile.get("groups", [])
 
     def get_is_autoconfirmed(self):
-        return "autoconfirmed" in self.get_user_groups()
+        if "autoconfirmed" in self.get_user_groups():
+            return True
+
+        try:
+            username = self.get_username()
+            if username in settings.WHITELISTED_USERS:
+                return True
+        except ServerError:
+            pass
+
+        return False
 
     def get_is_blocked(self):
         profile = self.get_profile()

--- a/src/core/templatetags/quickstatements.py
+++ b/src/core/templatetags/quickstatements.py
@@ -1,0 +1,10 @@
+from django import template
+
+from core.models import Wikibase
+
+register = template.Library()
+
+
+@register.simple_tag
+def has_multiple_wikibases():
+    return Wikibase.objects.all().count() > 1

--- a/src/core/tests/test_env.py
+++ b/src/core/tests/test_env.py
@@ -3,4 +3,4 @@ import os
 
 def test_environment_variables_are_not_set_to_real_servers():
     assert os.getenv("OAUTH_AUTHORIZATION_SERVER") == "https://oauth.example.org"
-    assert os.getenv("BASE_REST_URL") == "https://wikidata.example.org"
+    assert os.getenv("DEFAULT_WIKIBASE_URL") == "https://wikidata.example.org"

--- a/src/qsts3/settings.py
+++ b/src/qsts3/settings.py
@@ -174,10 +174,10 @@ LOGGING = {
             "handlers": ["console"],
             "level": "INFO",
         },
-        'urllib3': {
-            'handlers': ['console'],
-            'level': 'INFO',
-            'propagate': True,
+        "urllib3": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
         },
     },
 }
@@ -224,9 +224,10 @@ OAUTH_PROFILE_URL = os.getenv(
     f"{OAUTH_AUTHORIZATION_SERVER}/w/rest.php/oauth2/resource/profile",
 )
 
+WHITELISTED_USERS = [n.strip() for n in os.getenv("WHITELISTED_USERS", "").split(",")]
 
-# Base REST url
-BASE_REST_URL = os.getenv("BASE_REST_URL", "https://www.wikidata.org")
+# Default Wikibase
+DEFAULT_WIKIBASE_URL = os.getenv("DEFAULT_WIKIBASE_URL", "https://www.wikidata.org")
 
 # To use with EditGroups integration
 TOOLFORGE_TOOL_NAME = os.getenv("TOOLFORGE_TOOL_NAME")

--- a/src/web/templates/batch.html
+++ b/src/web/templates/batch.html
@@ -8,11 +8,13 @@
 {% endblock %}
 
 {% block content %}
-
 <div style="float: left;">
 <hgroup>
   <h2> {% translate "Batch" %} #{{ batch.pk }} <img id="spinner" class="htmx-indicator"></h2>
   <p><b>{{batch.name}}</b></p>
+  {% if multiple_wikis %}
+  <p>{% translate 'Submitted to' %}: {{ batch.wikibase }}</p>
+  {% endif %}
   <p>
     {% translate 'Created by' %}
     <a href="https://www.wikidata.org/wiki/User:{{batch.user}}">{{ batch.user }}</a>
@@ -52,7 +54,7 @@
 {% endif %}
 
 
-<div id="batchProgressDiv" 
+<div id="batchProgressDiv"
       hx-get="{% url 'batch_summary' pk=batch.pk %}"
       hx-trigger="load"
       hx-swap="outerHTML"
@@ -63,10 +65,10 @@
 
 <h4>{% translate "Commands" %}</h4>
 
-<div class="overflow-auto" 
-    id="batchCommandsDiv" 
+<div class="overflow-auto"
+    id="batchCommandsDiv"
     hx-get="{% url 'batch_commands' pk=batch.pk %}"
-    hx-trigger="load, reload" 
+    hx-trigger="load, reload"
     hx-indicator="#spinner"
     hx-swap="innerHTML">
 {% translate "Loading commands..." %}
@@ -107,4 +109,3 @@ function stop() {
 
 </script>
 {% endblock scripts %}
-

--- a/src/web/templates/layout.html
+++ b/src/web/templates/layout.html
@@ -1,5 +1,7 @@
 {% load i18n %}
-{% load static %}
+{% load static quickstatements %}
+
+{% has_multiple_wikibases as multiple_wikis %}
 
 <!DOCTYPE HTML>
 <html>
@@ -58,7 +60,7 @@
 
     {% block css %}
     {% endblock %}
-    
+
   </style>
 </head>
 

--- a/src/web/templates/new_batch.html
+++ b/src/web/templates/new_batch.html
@@ -22,6 +22,18 @@
 <form method="POST">
   {% csrf_token %}
   <fieldset>
+    {% if multiple_wikis %}
+    <label for="wikibase">{% translate "Wikibase" %}</label>
+
+    <select name="wikibase" id="wikibase">
+      {% for wikibase in wikibases %}
+      <option value="{{ wikibase.url }}">{{ wikibase.url }} ({{ wikibase.description|default:"No description" }}) </option>
+      {% endfor %}
+    </select>
+    {% else %}
+    <input name="wikibase" type="hidden" value="{{ wikibases.0.url }}" />
+    {% endif %}
+
     <label for="batch_type">{% translate "Command format" %}</label>
 
     <select name="type" id="batch_type">

--- a/src/web/templates/preview_batch.html
+++ b/src/web/templates/preview_batch.html
@@ -9,6 +9,9 @@
     <hgroup>
         <h2> {% translate "Batch Preview" %} <img id="spinner" class="htmx-indicator"></h2>
         <p><b>{{batch.name}}</b></p>
+        {% if multiple_wikis %}
+        <p>{{ batch.wikibase }}</p>
+        {% endif %}
     </hgroup>
 </div>
 <div style="float: right;">


### PR DESCRIPTION
This PR is the continuation of the work on #52, and it allows users to choose what wikibase to submit their jobs. The option will only be presented when there are multiple wikibases configured for the quickstaments deployment. 