### PR TITLE
Allows label loading even when no user is logged in

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -298,7 +298,11 @@ class Client:
         # TODO: parallelize this
         batch_size = 50
         entity_id_list = list(entity_ids)
-        self.token.refresh_if_needed()
+        try:
+            self.token.refresh_if_needed()
+            headers=self.headers()
+        except UnauthorizedToken:
+            headers = None
 
         collected_labels = list()
 
@@ -316,7 +320,7 @@ class Client:
             logger.debug(
                 f"Sending GET request at {action_api}, languages={languages}, ids={ids}"
             )
-            response = requests.get(action_api, headers=self.headers(), params=params)
+            response = requests.get(action_api, headers=headers, params=params)
             self.raise_for_status(response)
             response_data = response.json()
             for entity_id, entity_data in response_data["entities"].items():

--- a/src/web/models.py
+++ b/src/web/models.py
@@ -76,10 +76,12 @@ class Token(models.Model):
 
 class PreferencesManager(models.Manager):
     def get_language(self, user, default):
+        if user is None or not user.is_authenticated:
+            return default
         try:
-            prefs = self.get_queryset().get(user=user)
-            return prefs.language if prefs.language else default
-        except Preferences.DoesNotExist:
+            prefs = self.get_queryset().only('language').get(user=user)
+            return prefs.language or default
+        except self.model.DoesNotExist:
             return default
 
 


### PR DESCRIPTION
Fixes #311.

Since the Action API request for retrieving labels does not require authentication, we can allow labels to be loaded for any commands listing request, regardless of user authentication.