### PR TITLE
Move localization of labels from server to client-side

### DIFF
--- a/src/core/templatetags/quickstatements.py
+++ b/src/core/templatetags/quickstatements.py
@@ -1,6 +1,7 @@
 from django import template
+from django.utils.safestring import mark_safe
 
-from core.models import Wikibase, Label
+from core.models import Wikibase
 
 register = template.Library()
 
@@ -10,17 +11,17 @@ def has_multiple_wikibases():
     return Wikibase.objects.all().count() > 1
 
 
+@register.simple_tag(takes_context=True)
+def label_display(context, entity_id):
+    return mark_safe(
+        f'<span class="wikibase-label" data-entity-id="{entity_id}">{entity_id}</span>'
+    )
+
+
 @register.filter
-def label_display(entity_id, user):
+def language_preference(user):
     # FIXME: Preferences need to be moved to core module, so that
     # we can properly catch the RelatedObjectDoesNotExist
     # exception
     preferences = getattr(user, "preferences", None)
-    lang = preferences and preferences.language
-
-    label = lang and Label.objects.filter(entity_id=entity_id, language=lang).first()
-
-    if not label:
-        label = Label.objects.filter(entity_id=entity_id, language="en").first()
-
-    return label and label.value
+    return preferences and preferences.language or "en"

--- a/src/core/tests/test_api.py
+++ b/src/core/tests/test_api.py
@@ -449,30 +449,6 @@ class ClientTests(TestCase):
             self.api_client().get_property_value_type("P1")
 
     @requests_mock.Mocker()
-    def test_get_labels(self, mocker):
-        labels = {
-            "Q123": {
-                "en": "English label",
-                "pt": "Portuguese label",
-            }
-        }
-        client = self.api_client()
-        Label.objects.all().delete()
-        self.api_mocker.labels(mocker, client, labels)
-        client.fetch_entity_labels(["Q123"], "pt")
-        self.assertEqual(Label.objects.count(), 2)
-        self.assertTrue(
-            Label.objects.filter(
-                entity_id="Q123", language="en", value="English label"
-            ).exists()
-        )
-        self.assertTrue(
-            Label.objects.filter(
-                entity_id="Q123", language="pt", value="Portuguese label"
-            ).exists()
-        )
-
-    @requests_mock.Mocker()
     def test_verify_value_type(self, mocker):
         self.api_mocker.wikidata_property_data_types(mocker)
         self.api_mocker.property_data_type(mocker, "P1", "commonsMedia")

--- a/src/core/tests/test_batch_processing.py
+++ b/src/core/tests/test_batch_processing.py
@@ -536,38 +536,6 @@ class ProcessingTests(TestCase):
             self.assertEqual(command.status, BatchCommand.STATUS_ERROR)
 
     @requests_mock.Mocker()
-    def test_get_label(self, mocker):
-        self.api_mocker.wikidata_property_data_types(mocker)
-        self.api_mocker.is_autoconfirmed(mocker)
-        self.api_mocker.create_item(mocker, "Q1")
-        self.api_mocker.item_empty(mocker, "Q1")
-        self.api_mocker.item_empty(mocker, "Q2")
-        self.api_mocker.property_data_type(mocker, "P1", "quantity")
-        self.api_mocker.patch_item_successful(mocker, "Q1", {})
-        self.api_mocker.patch_item_successful(mocker, "Q2", {})
-        batch = self.parse(
-            """
-        CREATE
-        LAST|P1|12
-        Q2|P1|15
-        """
-        )
-        batch.combine_commands = True
-        commands = batch.commands()
-        labels = {
-            "Q1": {"pt": "pt1", "en": "en1"},
-            "Q2": {"pt": "pt2", "en": "en2"},
-            "P1": {"pt": "prop_pt", "en": "prop_en"},
-        }
-        self.api_mocker.labels(mocker, self.api_client, labels)
-        BatchCommand.load_labels(self.api_client, commands, "pt")
-        self.assertEqual(commands[0].labels.count(), 0)
-        self.assertEqual(
-            commands[1].labels.filter(entity_id="P1", language="pt").count(), 1
-        )
-        self.assertEqual(commands[2].labels.filter(entity_id="Q2").count(), 2)
-
-    @requests_mock.Mocker()
     def test_remove_qual_or_ref_errors(self, mocker):
         self.api_mocker.item(
             mocker,

--- a/src/web/templates/_batch_load_command_labels.html
+++ b/src/web/templates/_batch_load_command_labels.html
@@ -1,0 +1,35 @@
+{% load quickstatements %}
+
+<script language="javascript">
+ async function loadLabels(container) {
+   const spans = container.querySelectorAll("span.wikibase-label[data-entity-id]")
+   if (spans.length === 0) return
+
+   const entityIds = Array.from(spans).map(span => span.getAttribute("data-entity-id"))
+
+   const userLanguage = "{{ user|language_preference }}"
+
+   const languages = userLanguage === "en" ? "en" : `${userLanguage}|en`
+
+   const url = `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${entityIds.join('|')}&format=json&languages=${languages}&props=labels&origin=*`
+
+   try {
+     const res = await fetch(url)
+     const data = await res.json()
+
+     spans.forEach(span => {
+       const id = span.getAttribute("data-entity-id")
+       const localizedLabel = data.entities?.[id]?.labels?.[userLanguage]?.value
+       const englishLabel = data.entities?.[id]?.labels?.en?.value
+
+       const label = localizedLabel || englishLabel
+
+       if (label) {
+         span.textContent = label
+       }
+     })
+   } catch (err) {
+     console.error("Error fetching localized labels from Wikidata:", err)
+   }
+ }
+</script>

--- a/src/web/templates/batch.html
+++ b/src/web/templates/batch.html
@@ -95,17 +95,26 @@
 
 {% block scripts %}
 <script>
-function showStopModal() {
-    document.getElementById("confirmStop").setAttribute("open", "");
-}
+ function showStopModal() {
+   document.getElementById("confirmStop").setAttribute("open", "");
+ }
 
-function closeStopModal() {
-    document.getElementById("confirmStop").removeAttribute("open", "");
-}
+ function closeStopModal() {
+   document.getElementById("confirmStop").removeAttribute("open", "");
+ }
 
-function stop() {
-    document.getElementById("stopbatch").submit();
-}
+ function stop() {
+   document.getElementById("stopbatch").submit();
+ }
+</script>
+{% include '_batch_load_command_labels.html' %}
 
+<script language="javascript">
+ document.addEventListener('htmx:afterSwap', async (event) => {
+   if (event.target.id != 'batchCommandsDiv') {
+     return
+   }
+   await loadLabels(event.target)
+ })
 </script>
 {% endblock scripts %}

--- a/src/web/templates/batch_commands.html
+++ b/src/web/templates/batch_commands.html
@@ -13,7 +13,7 @@
       </td>
 
       <td>
-        {{ command.entity_id|label_display:user }}
+        {% label_display command.entity_id %}
         {% if command.entity_url %}
         <a href="{{ command.entity_url }}">{{ command.entity_info }}</a>
         {% else %}
@@ -47,15 +47,15 @@
             {{ command.json.item1 }} - {{ command.json.item2 }}
           {% elif command.is_sitelink_command %}
             <i>{{ command.sitelink }}</i>:
-          {% elif command.prop != "" %}
-            {{ command.prop|label_display:user }}
+            {% elif command.prop != "" %}
+            {% label_display command.prop %}
             <a href="{{ command.batch.wikibase.url }}/entity/{{ command.prop }}">
               [{{ command.prop }}]
             </a>:
             {% endif %}
 
             {% if command.value_type == "wikibase-entityid" %}
-            {{ command.value_value|label_display:user }}
+            {% label_display command.value_value %}
             <a href="{{ command.batch.wikibase.url }}/entity/{{ command.value_value }}">
               [{{ command.value_value }}]<br>
             </a>
@@ -66,12 +66,12 @@
         {% if command.qualifiers|length > 0 %}
         <hr style="margin: revert;">
             {% for qual in command.qualifiers %}
-            <b data-tooltip="{% translate 'Qualifier' context 'batch-commands-qualifier' %}">Q.</b> {{ qual.property|label_display:user }}
-            <a href="{{ command.batch.wikibase.url }}/entity/{{ qual.property }}">
-              [{{ qual.property }}]
-            </a>:
-              {% if qual.value.type == "wikibase-entityid" %}
-              {{ qual.value.value|label_display:user }}
+        <b data-tooltip="{% translate 'Qualifier' context 'batch-commands-qualifier' %}">Q.</b> {% label_display qual.property %}
+        <a href="{{ command.batch.wikibase.url }}/entity/{{ qual.property }}">
+          [{{ qual.property }}]
+        </a>:
+        {% if qual.value.type == "wikibase-entityid" %}
+        {% label_display qual.value.value %}
               <a href="{{ command.batch.wikibase.url }}/entity/{{ qual.value.value }}">
                 [{{ qual.value.value }}]
               </a><br>
@@ -85,12 +85,12 @@
           {% for reference_block in command.references %}
             <hr style="margin: revert;">
             {% for ref in reference_block %}
-              <b data-tooltip="{% translate 'Reference Part' context 'batch-commands-reference-part' %}">R.</b> {{ ref.property|label_display:user }}
-              <a href="{{ command.batch.wikibase.url }}/entity/{{ ref.property }}">
-                [{{ ref.property }}]
-              </a>:
-              {% if ref.value.type == "wikibase-entityid" %}
-                {{ ref.value.value|label_display:user }}
+            <b data-tooltip="{% translate 'Reference Part' context 'batch-commands-reference-part' %}">R.</b> {% label_display ref.property %}
+            <a href="{{ command.batch.wikibase.url }}/entity/{{ ref.property }}">
+              [{{ ref.property }}]
+            </a>:
+            {% if ref.value.type == "wikibase-entityid" %}
+            {% label_display ref.value.value %}
                 <a href="{{ command.batch.wikibase.url }}/entity/{{ ref.value.value }}">
                   [{{ ref.value.value }}]
                 </a><br>

--- a/src/web/templates/preview_batch.html
+++ b/src/web/templates/preview_batch.html
@@ -4,6 +4,19 @@
 {% block css %}
 {% include '_batch_css.html' %}
 {% endblock %}
+
+{% block scripts %}
+{% include '_batch_load_command_labels.html' %}
+<script language="javascript">
+  document.addEventListener('htmx:afterSwap', async (event) => {
+  if (event.target.id != 'batchCommandsDiv') {
+    return
+  }
+  await loadLabels(event.target)
+  })
+</script>
+{% endblock %}
+
 {% block content %}
 <div style="float: left;">
     <hgroup>

--- a/src/web/views/batch.py
+++ b/src/web/views/batch.py
@@ -90,7 +90,6 @@ def batch_restart(request, pk):
         return HttpResponse("403 Forbidden", status=403)
 
 
-
 @require_http_methods(
     [
         "POST",
@@ -102,9 +101,8 @@ def batch_rerun(request, pk):
     """
     try:
         batch = Batch.objects.get(pk=pk)
-        user_is_authorized = (
-            request.user.is_authenticated and
-            (request.user.username == batch.user or request.user.is_superuser)
+        user_is_authorized = request.user.is_authenticated and (
+            request.user.username == batch.user or request.user.is_superuser
         )
         assert user_is_authorized
         batch.rerun()
@@ -160,15 +158,6 @@ def batch_commands(request, pk):
 
     paginator = Paginator(qs.order_by("index"), page_size)
     page = paginator.page(page)
-
-    try:
-        token = Token.objects.get(user__username=batch.user)
-        language = Preferences.objects.get_language(request.user, "en")
-        client = Client(token=token, wikibase=batch.wikibase)
-        BatchCommand.load_labels(client, page.object_list, "en")
-    except (UnauthorizedToken, ServerError, Token.DoesNotExist):
-        pass
-
     base_url = reverse("batch_commands", args=[pk])
     return render(
         request,

--- a/src/web/views/new_batch.py
+++ b/src/web/views/new_batch.py
@@ -107,13 +107,6 @@ def preview_batch_commands(request):
         paginator = Paginator(batch_commands, page_size)
         page = paginator.page(page)
 
-        if request.user.is_authenticated:
-            token = Token.objects.filter(user=request.user).first()
-            if token is not None:
-                client = Client(token=token, wikibase=batch.wikibase)
-                language = Preferences.objects.get_language(request.user, "en")
-                BatchCommand.load_labels(client, page.object_list, language)
-
     base_url = reverse("preview_batch_commands")
     return render(
         request,


### PR DESCRIPTION
 - Removes `load_labels` logic from batch views
 - Adds a template tag where entity ids get special markup (<span class="wikibase-label" data-entity-id={entity_id}">{entity_id}</span>
 - Adds a javascript function snippet which can query for these span elements
 - Calls the function on htmx:afterSwap event.