### PR TITLE
Hide preview batches in lists

### DIFF
--- a/src/web/views/batches.py
+++ b/src/web/views/batches.py
@@ -9,12 +9,7 @@ from core.models import Batch
 PAGE_SIZE = 25
 
 
-@require_http_methods(
-    [
-        "GET",
-        "HEAD",
-    ]
-)
+@require_http_methods(["GET", "HEAD"])
 def home(request):
     """
     Main page for this tool
@@ -22,11 +17,7 @@ def home(request):
     return render(request, "index.html")
 
 
-@require_http_methods(
-    [
-        "GET",
-    ]
-)
+@require_http_methods(["GET"])
 def last_batches(request):
     """
     List last PAGE_SIZE batches modified
@@ -38,18 +29,19 @@ def last_batches(request):
         page = 1
         page_size = PAGE_SIZE
 
-    paginator = Paginator(Batch.objects.all().order_by("-modified"), page_size)
+    paginator = Paginator(
+        Batch.objects.exclude(status=Batch.STATUS_PREVIEW).order_by("-modified"),
+        page_size,
+    )
     base_url = reverse("last_batches")
     return render(
-        request, "batches.html", {"page": paginator.page(page), "base_url": base_url, "page_size": page_size}
+        request,
+        "batches.html",
+        {"page": paginator.page(page), "base_url": base_url, "page_size": page_size},
     )
 
 
-@require_http_methods(
-    [
-        "GET",
-    ]
-)
+@require_http_methods(["GET"])
 def last_batches_by_user(request, user):
     """
     List last PAGE_SIZE batches modified created by user
@@ -61,13 +53,17 @@ def last_batches_by_user(request, user):
         page = 1
         page_size = PAGE_SIZE
 
-    paginator = Paginator(
-        Batch.objects.filter(user=user).order_by("-modified"), page_size
-    )
+    batches = Batch.objects.filter(user=user).exclude(status=Batch.STATUS_PREVIEW)
+    paginator = Paginator(batches.order_by("-modified"), page_size)
     base_url = reverse("last_batches_by_user", args=[user])
     # we need to use `username` since `user` is always supplied by django templates
     return render(
         request,
         "batches.html",
-        {"username": user, "page": paginator.page(page), "base_url": base_url, "page_size": page_size},
+        {
+            "username": user,
+            "page": paginator.page(page),
+            "base_url": base_url,
+            "page_size": page_size,
+        },
     )

--- a/src/web/views/new_batch.py
+++ b/src/web/views/new_batch.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from django.contrib.auth.decorators import login_required
-from django.core import serializers
 from django.core.paginator import Paginator
 from django.shortcuts import redirect, render
 from django.urls import reverse
@@ -21,7 +20,6 @@ from core.models import (
 from core.parsers.base import ParserException
 from core.parsers.csv import CSVCommandParser
 from core.parsers.v1 import V1CommandParser
-from web.models import Preferences
 
 from .auth import logout_per_token_expired
 
@@ -128,10 +126,6 @@ def new_batch(request):
 
     if request.method == "POST":
         try:
-            # We delete any previous batches that were in preview mode
-            BatchEditingSession.objects.filter(
-                session_key=request.session.session_key
-            ).delete()
             Batch.objects.filter(
                 status=Batch.STATUS_PREVIEW, user=request.user.username
             ).delete()


### PR DESCRIPTION
Also, delete any batches in preview from an user when they submit a new batch. This is to ensure that we are not leaving dangling batches which can not be edited again.

Closes #310.