### PR TITLE
Prevents duplication of reference blocks

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1220,25 +1220,14 @@ class BatchCommand(models.Model):
             self.statement_rank(),
         )
 
-        duplicate_statement = True
-        if refs:
-            for ref in refs:
-                for ref_part in ref["parts"]:
-                    if not self.is_part_in_references(ref_part):
-                        duplicate_statement = False
-                        break
-            if quals and duplicate_statement:
-                for q in quals:
-                    if not self.is_in_qualifiers(q):
-                        duplicate_statement = False
-                        break
-
         if quals:
             st.setdefault("qualifiers", [])
             st["qualifiers"].extend(quals)
-        if refs and not duplicate_statement:
+        if refs:
             st.setdefault("references", [])
-            st["references"].extend(refs)
+            for ref in refs:
+                if ref not in st["references"]:
+                    st["references"].append(ref)
         if rank:
             st["rank"] = rank
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1219,10 +1219,24 @@ class BatchCommand(models.Model):
             self.references_for_api(),
             self.statement_rank(),
         )
+
+        duplicate_statement = True
+        if refs:
+            for ref in refs:
+                for ref_part in ref["parts"]:
+                    if not self.is_part_in_references(ref_part):
+                        duplicate_statement = False
+                        break
+            if quals and duplicate_statement:
+                for q in quals:
+                    if not self.is_in_qualifiers(q):
+                        duplicate_statement = False
+                        break
+
         if quals:
             st.setdefault("qualifiers", [])
             st["qualifiers"].extend(quals)
-        if refs:
+        if refs and not duplicate_statement:
             st.setdefault("references", [])
             st["references"].extend(refs)
         if rank:


### PR DESCRIPTION
Deals with #153.

This PR prevents the insertion of duplicated reference blocks for blocks that are already in the item statement.
We still need to deal with the insertion of duplicated reference blocks, as in:
`Q4115189|P31|Q4115189|S143|Q4115189|!S43|Q4115189`