### PR TITLE
Reverse Y axis labels

### DIFF
--- a/src/web/templates/statistics_plots.html
+++ b/src/web/templates/statistics_plots.html
@@ -153,14 +153,14 @@
                 },
                 title: {
                   display: true,
-                  text: scriptData.labelNumberOfEdits
+                  text: scriptData.labelNumberOfEditors
                 }
             },
             y1: {
                 position: 'left',
                 title: {
                   display: !hideEditorsPlot,
-                  text: scriptData.labelNumberOfEditors
+                  text: scriptData.labelNumberOfEdits
                 }
             }
         },


### PR DESCRIPTION
In the _Cumulative number of edits and new editors_ graph on https://qs-dev.toolforge.org/statistics/, the two Y axis labels are reversed.