### PR TITLE
Send bot flag = True for edits

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1891,10 +1891,10 @@ class BatchCommand(models.Model):
         """
         Returns the final Wikibase API body.
 
-        Joins the api payload with bot marking = False and the edit summary.
+        Joins the api payload with bot marking = True and the edit summary.
         """
         body = self.api_payload(client)
-        body["bot"] = False
+        body["bot"] = True
         body["comment"] = self.edit_summary()
         return body
 

--- a/src/core/tests/test_api.py
+++ b/src/core/tests/test_api.py
@@ -653,7 +653,7 @@ class TestBatchCommand(TestCase):
             cmd.api_body(self.api_client),
             {
                 "item": {},
-                "bot": False,
+                "bot": True,
                 "comment": comment,
             },
         )


### PR DESCRIPTION
The Wikibase REST API recently changed its behavior when receiving requests with `"bot": true` in the request payload. The server no longer rejects such requests if the account associated with the request doesn't have the bot permissions. In those cases, it simply lets the edit go through without marking it as a bot edit (see [T421631](https://phabricator.wikimedia.org/T421631)).

This means that QuickStatements can safely always send `"bot": true` so that edits made by bots get marked as such. This will not have any effect for edits made by non-bots.